### PR TITLE
Update release-draft-template.yml

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -2,6 +2,7 @@ name-template: 'v$RESOLVED_VERSION 🐙'
 tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'skip-changelog'
+  - 'dependencies'
 version-resolver:
   minor:
     labels:
@@ -18,3 +19,6 @@ template: |
   Thanks again to $CONTRIBUTORS! 🦩
 no-changes-template: 'Changes are coming soon 😎'
 sort-direction: 'ascending'
+replacers:
+  - search: '/(?:and )?@dependabot-preview(?:\[bot\])?,?/g'
+    replace: ''


### PR DESCRIPTION
- Skip PR with 'dependencies' label
- Use replacer to remove dependabot from $CONTRIBUTORS

See https://github.com/release-drafter/release-drafter/issues/569